### PR TITLE
GP-066 Fix sql connection strings for deploy and web.config environment

### DIFF
--- a/src/GeoPing.Api/appsettings.production.json
+++ b/src/GeoPing.Api/appsettings.production.json
@@ -1,5 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=_CHANGE_ME;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=WEBSERVER;Database=aspnet-GeoPing.Api-Production;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }


### PR DESCRIPTION
- Server name changed from local to WEBSERVER
- DB name changed from _CHANGE_ME to aspnet-GeoPing.Api-Production