### PR TITLE
GP-125 Return user roles with another short info (avatar, username and id)

### DIFF
--- a/src/GeoPing.Api/Controllers/AccountController.cs
+++ b/src/GeoPing.Api/Controllers/AccountController.cs
@@ -125,15 +125,15 @@ namespace GeoPing.Api.Controllers
         // GET /account/profile/short
         [HttpGet]
         [Route("profile/short")]
-        public IActionResult GetShortProfile()
+        public async Task<IActionResult> GetShortProfile()
         {
-            var userId = _helper.GetAppUserIdByClaims(User.Claims);
-            var result = _accountSrv.GetShortProfile(userId);
+            var result = await _accountSrv.GetShortProfile(_helper.GetIdentityUserIdByClaims(User.Claims));
 
             if (result.Success)
             {
                 return Ok(result);
             }
+
             return BadRequest(result);
         }
 

--- a/src/GeoPing.Core/Models/DTO/ShortUserInfoDTO .cs
+++ b/src/GeoPing.Core/Models/DTO/ShortUserInfoDTO .cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace GeoPing.Core.Models.DTO
 {
@@ -7,5 +8,6 @@ namespace GeoPing.Core.Models.DTO
         public string UserName { get; set; }
         public string Avatar { get; set; }
         public Guid UserId { get; set; }
+        public IEnumerable<string> Roles { get; set; }
     }
 }

--- a/src/GeoPing.Core/Services/IAccountService.cs
+++ b/src/GeoPing.Core/Services/IAccountService.cs
@@ -16,7 +16,7 @@ namespace GeoPing.Core.Services
         Task<OperationResult> ConfirmResetAsync(string token, string newPassword);
         Task ConfirmAccountWithoutEmailAsync(string userEmail);
         OperationResult<GeoPingUser> GetProfile(Guid gpUserId);
-        OperationResult<ShortUserInfoDTO> GetShortProfile(Guid userId);
+        Task<OperationResult<ShortUserInfoDTO>> GetShortProfile(string userId);
         OperationResult<GeoPingUser> EditProfile(Guid loggedUserId, GeoPingUserDTO user);
         OperationResult<GeoPingUser> EditProfileAvatar(Guid guid, ProfileAvatarDTO avatar);
         Task<OperationResult> ResetPassword(ResetPasswordDTO form);

--- a/src/GeoPing.Core/Services/IGeopingUserService.cs
+++ b/src/GeoPing.Core/Services/IGeopingUserService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using GeoPing.Core.Models;
 using GeoPing.Core.Models.DTO;
 using GeoPing.Core.Models.Entities;
@@ -12,7 +13,7 @@ namespace GeoPing.Core.Services
     {
         IQueryable<GeoPingUser> GetUsers(Expression<Func<GeoPingUser, bool>> func);
         GeoPingUser GetUser(Expression<Func<GeoPingUser, bool>> func);
-        ShortUserInfoDTO GetUserNameAndAvatar(Expression<Func<GeoPingUser, bool>> func);
+        Task<ShortUserInfoDTO> GetUserCommonInfo(string userId);
         GeoPingUser AddGPUserForIdentity(string identityUserId, string email, string username);
         OperationResult<GeoPingUser> EditUser(GeoPingUser user);
         void ActivateUser(string id);

--- a/src/Geoping.Services/AccountService.cs
+++ b/src/Geoping.Services/AccountService.cs
@@ -335,9 +335,9 @@ namespace GeoPing.Services
             };
         }
 
-        public OperationResult<ShortUserInfoDTO> GetShortProfile(Guid gpUserId)
+        public async Task<OperationResult<ShortUserInfoDTO>> GetShortProfile(string userId)
         {
-            var result = _gpUserSrv.GetUserNameAndAvatar(x => x.Id == gpUserId);
+            var result = await _gpUserSrv.GetUserCommonInfo(userId);
 
             if (result == null)
             {
@@ -346,6 +346,7 @@ namespace GeoPing.Services
                     Messages = new[] { "User was not found" }
                 };
             }
+
             return new OperationResult<ShortUserInfoDTO>
             {
                 Data = result,

--- a/tests/Geoping.Services.Tests/GPUserService.Tests.cs
+++ b/tests/Geoping.Services.Tests/GPUserService.Tests.cs
@@ -7,8 +7,10 @@ using GeoPing.Core;
 using GeoPing.Core.Models.DTO;
 using GeoPing.Core.Models.Entities;
 using GeoPing.Core.Services;
+using GeoPing.Infrastructure.Models;
 using GeoPing.Infrastructure.Repositories;
 using GeoPing.TestData.Helpers;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -21,6 +23,7 @@ namespace GeoPing.Services.Tests
     {
         private IRepository<GeoPingUser> _gpUserRepo;
         private Mock<IOptions<ApplicationSettings>> _settings;
+        private UserManager<AppIdentityUser> _usermanager;
 
         private IGeopingUserService _sut;
 
@@ -32,6 +35,7 @@ namespace GeoPing.Services.Tests
             _services = await new DataBaseDiBootstrapperInMemory().GetServiceProviderWithSeedDb();
 
             _gpUserRepo = _services.GetRequiredService<IRepository<GeoPingUser>>();
+            _usermanager = _services.GetRequiredService<UserManager<AppIdentityUser>>();
 
             _settings = new Mock<IOptions<ApplicationSettings>>();
             _settings
@@ -45,7 +49,7 @@ namespace GeoPing.Services.Tests
                     }
                 });
 
-            _sut = new GeopingUserService(_gpUserRepo, _settings.Object);
+            _sut = new GeopingUserService(_gpUserRepo, _settings.Object, _usermanager);
         }
 
         [Test]


### PR DESCRIPTION
- Added field Roles for ShortUserInfoDTO,
- Refactored GetShortProfile() and referenced GetUserCommonInfo(), now they take identityUserId as argument and implement return user Roles